### PR TITLE
Pop out a alert window when download finished

### DIFF
--- a/ShooterSubD/shooter.m
+++ b/ShooterSubD/shooter.m
@@ -101,6 +101,14 @@ static char * shooterURL = "http://shooter.cn/api/subapi.php?";
                                                [[NSNotificationCenter defaultCenter] postNotificationName: @"DownloadThreadFinish" object:nil userInfo:userInfo];
                                            });
                                        }
+                                       else
+                                       {
+                                           dispatch_async(dispatch_get_main_queue(), ^{
+                                               //notification post a notification ThreadFinish with filePath
+                                               NSDictionary *userInfo = [NSDictionary dictionaryWithObject:filePath forKey:@"filePath"];
+                                               [[NSNotificationCenter defaultCenter] postNotificationName: @"DownloadThreadFail" object:nil userInfo:userInfo];
+                                           });
+                                       }
                                    }
                                    
                                }];


### PR DESCRIPTION
If the program keep all the fail-downloaded row in the list view, we still do not know if these rows are downloaded fail or just being downloaded but not finished. Thus, I add a new feature that popping out an alert window when the program finished all the download try(successful or not).
