### PR TITLE
Update shooter.cn API URL

### DIFF
--- a/ShooterSubD/shooter.m
+++ b/ShooterSubD/shooter.m
@@ -12,7 +12,7 @@
 @implementation shooter
 
 // Shooter API.
-static char * shooterURL = "http://shooter.cn/api/subapi.php?";
+static char * shooterURL = "https://www.shooter.cn/api/subapi.php?";
 
 
 @synthesize videoHash, dict, encodedURL, linkType, Data;


### PR DESCRIPTION
According to the doc, https://docs.google.com/document/d/1ufdzy6jbornkXxsD-OGl3kgWa4P9WO5NZb6_QYZiGI0/preview, it looks like the URL has been changed, change to the latest one should work.